### PR TITLE
Do not throw an error when comparing two objects with different parents

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -89,10 +89,13 @@ function divides(x::T, y::T) where {T <: RingElem}
 end
 
 function ==(x::S, y::T) where {S <: RingElem, T <: RingElem}
-   if S == promote_rule(S, T)
+   R = promote_rule(S, T)
+   if S == R
       ==(x, parent(x)(y))
-   else
+   elseif T == R
       ==(parent(y)(x), y)
+   else
+      false
    end
 end
 

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -126,6 +126,15 @@ function deepcopy_internal(a::AbsSeries{T}, dict::IdDict) where {T <: RingElemen
    return parent(a)(coeffs, length(a), precision(a))
 end
 
+function Base.hash(a::AbstractAlgebra.AbsSeriesElem, h::UInt)
+   b = 0xb44d6896204881f3%UInt
+   for i in 0:length(a) - 1
+      b = xor(b, hash(coeff(a, i), h), h)
+      b = (b << 1) | (b >> (sizeof(Int)*8 - 1))
+   end
+   return b
+end
+
 ###############################################################################
 #
 #   AbstractString I/O
@@ -499,7 +508,9 @@ end
 > equal to the minimum of the two precisions.
 """
 function ==(x::AbstractAlgebra.AbsSeriesElem{T}, y::AbstractAlgebra.AbsSeriesElem{T}) where {T <: RingElement}
-   check_parent(x, y)
+   b = check_parent(x, y, false)
+   !b && return false
+
    prec = min(precision(x), precision(y))
    m1 = min(length(x), length(y))
    m2 = max(length(x), length(y))

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -51,8 +51,10 @@ function characteristic(R::AbstractAlgebra.FracField{T}) where T <: RingElem
    return characteristic(base_ring(R))
 end
 
-function check_parent(a::AbstractAlgebra.FracElem, b::AbstractAlgebra.FracElem)
-   parent(a) != parent(b) && error("Incompatible rings in fraction field operation")
+function check_parent(a::AbstractAlgebra.FracElem, b::AbstractAlgebra.FracElem, throw::Bool = true)
+   fl = parent(a) != parent(b)
+   fl && throw && error("Incompatible rings in fraction field operation")
+   return !fl
 end
 
 ###############################################################################
@@ -513,7 +515,9 @@ end
 > equal to the minimum of the two precisions.
 """
 function ==(x::AbstractAlgebra.FracElem{T}, y::AbstractAlgebra.FracElem{T}) where {T <: RingElem}
-   check_parent(x, y)
+   b  = check_parent(x, y, false)
+   !b && return false
+
    return (AbstractAlgebra.denominator(x, false) == AbstractAlgebra.denominator(y, false) &&
            AbstractAlgebra.numerator(x, false) == AbstractAlgebra.numerator(y, false)) ||
           (AbstractAlgebra.denominator(x, true) == AbstractAlgebra.denominator(y, true) &&

--- a/src/generic/LaurentSeries.jl
+++ b/src/generic/LaurentSeries.jl
@@ -76,9 +76,10 @@ var(a::LaurentSeriesRing) = a.S
 """
 var(a::LaurentSeriesField) = a.S
 
-function check_parent(a::LaurentSeriesElem, b::LaurentSeriesElem)
-   parent(a) != parent(b) &&
-             error("Incompatible power series rings in Laurent series operation")
+function check_parent(a::LaurentSeriesElem, b::LaurentSeriesElem, throw::Bool = true)
+   b = parent(a) != parent(b)
+   b && throw && error("Incompatible power series rings in Laurent series operation")
+   return !b
 end
 
 ###############################################################################
@@ -945,7 +946,8 @@ end
 > equal to the minimum of the two precisions.
 """
 function ==(x::LaurentSeriesElem{T}, y::LaurentSeriesElem{T}) where {T <: RingElement}
-   check_parent(x, y)
+   b = check_parent(x, y, false)
+   !b && return false
    xval = valuation(x)
    xprec = precision(x)
    yval = valuation(y)

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -210,9 +210,10 @@ function ordering(a::MPolyRing{T}) where {T <: RingElement}
    return a.ord
 end
 
-function check_parent(a::MPoly{T}, b::MPoly{T}) where T <: RingElement
-   parent(a) != parent(b) &&
-      error("Incompatible polynomial rings in polynomial operation")
+function check_parent(a::MPoly{T}, b::MPoly{T}, throw::Bool = true) where T <: RingElement
+   b = parent(a) != parent(b)
+   b & throw && error("Incompatible polynomial rings in polynomial operation")
+   return !b
 end
 
 ###############################################################################
@@ -1842,7 +1843,8 @@ end
 ###############################################################################
 
 function ==(a::MPoly{T}, b::MPoly{T}) where {T <: RingElement}
-   check_parent(a,b)
+   fl = check_parent(a, b, false)
+   !fl && return false
    if a.length != b.length
       return false
    end
@@ -1888,6 +1890,8 @@ function ==(a::MPoly, n::Union{Integer, Rational, AbstractFloat})
    return false
 end
 
+==(n::Union{Integer, Rational, AbstractFloat}, a::MPoly) = a == n
+
 function ==(a::MPoly{T}, n::T) where {T <: RingElem}
    N = size(a.exps, 1)
    if n == 0
@@ -1897,6 +1901,8 @@ function ==(a::MPoly{T}, n::T) where {T <: RingElem}
    end
    return false
 end
+
+==(n::T, a::MPoly{T}) where {T <: RingElem} = a == n
 
 ###############################################################################
 #
@@ -4304,6 +4310,10 @@ promote_rule(::Type{MPoly{T}}, ::Type{MPoly{T}}) where T <: RingElement = MPoly{
 function promote_rule(::Type{MPoly{T}}, ::Type{U}) where {T <: RingElement, U <: RingElement}
    promote_rule(T, U) == T ? MPoly{T} : Union{}
 end
+
+#function promote_rule(::Type{T}, ::Type{MPoly{T}}) where {T <: RingElement}
+#   return MPoly{T}
+#end
 
 ###############################################################################
 #

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -104,9 +104,10 @@ base_ring(a::MatrixElem{T}) where {T <: RingElement} = a.base_ring::parent_type(
 parent(a::AbstractAlgebra.MatElem{T}, cached::Bool = true) where T <: RingElement =
     MatSpace{T}(a.base_ring, size(a.entries)..., cached)
 
-function check_parent(a::AbstractAlgebra.MatElem, b::AbstractAlgebra.MatElem)
-  (base_ring(a) != base_ring(b) || nrows(a) != nrows(b) || ncols(a) != ncols(b)) &&
-                error("Incompatible matrix spaces in matrix operation")
+function check_parent(a::AbstractAlgebra.MatElem, b::AbstractAlgebra.MatElem, throw::Bool = true)
+  fl = (base_ring(a) != base_ring(b) || nrows(a) != nrows(b) || ncols(a) != ncols(b))
+  fl && throw && error("Incompatible matrix spaces in matrix operation")
+  return !fl
 end
 
 function _check_dim(r::Int, c::Int, arr::AbstractArray{T, 2}, transpose::Bool = false) where {T}
@@ -677,7 +678,8 @@ end
 > equal to the minimum of the two precisions.
 """
 function ==(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: RingElement}
-   check_parent(x, y)
+   b = check_parent(x, y, false)
+   !b && return false
    for i = 1:nrows(x)
       for j = 1:ncols(x)
          if x[i, j] != y[i, j]
@@ -696,7 +698,8 @@ end
 > are they declared equal by this function.
 """
 function isequal(x::MatrixElem{T}, y::MatrixElem{T}) where {T <: RingElement}
-   check_parent(x, y)
+   b = check_parent(x, y, false)
+   !b && return false
    for i = 1:nrows(x)
       for j = 1:ncols(x)
          if !isequal(x[i, j], y[i, j])

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -31,9 +31,10 @@ end
 parent(a::AbstractAlgebra.MatAlgElem{T}, cached::Bool = true) where T <: RingElement =
     MatAlgebra{T}(a.base_ring, size(a.entries)[1], cached)
 
-function check_parent(a::AbstractAlgebra.MatAlgElem{T}, b::AbstractAlgebra.MatAlgElem{T}) where T <: RingElement
-  (base_ring(a) != base_ring(b) || degree(a) != degree(b)) &&
-                error("Incompatible matrix spaces in matrix operation")
+function check_parent(a::AbstractAlgebra.MatAlgElem{T}, b::AbstractAlgebra.MatAlgElem{T}, throw::Bool = true) where T <: RingElement
+  fl = (base_ring(a) != base_ring(b) || degree(a) != degree(b)) 
+  fl && throw && error("Incompatible matrix spaces in matrix operation")
+  return !fl
 end
 
 isexact_type(::Type{MatAlgElem{T}}) where T <: RingElement = isexact_type(T)

--- a/src/generic/NCPoly.jl
+++ b/src/generic/NCPoly.jl
@@ -297,7 +297,8 @@ end
 > equal to the minimum of the two precisions.
 """
 function ==(x::AbstractAlgebra.NCPolyElem{T}, y::AbstractAlgebra.NCPolyElem{T}) where {T <: NCRingElem}
-   check_parent(x, y)
+   b = check_parent(x, y, false)
+   !b && return false
    if length(x) != length(y)
       return false
    else

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -67,9 +67,10 @@ var(a::AbstractAlgebra.PolyRing) = a.S
 """
 symbols(a::AbstractAlgebra.PolyRing) = [a.S]
 
-function check_parent(a::PolynomialElem, b::PolynomialElem)
-   parent(a) != parent(b) &&
-                error("Incompatible polynomial rings in polynomial operation")
+function check_parent(a::PolynomialElem, b::PolynomialElem, throw::Bool = true)
+   b = parent(a) != parent(b)
+   b && throw && error("Incompatible polynomial rings in polynomial operation")
+   return !b
 end
 
 ###############################################################################
@@ -707,7 +708,8 @@ end
 > equal to the minimum of the two precisions.
 """
 function ==(x::AbstractAlgebra.PolyElem{T}, y::AbstractAlgebra.PolyElem{T}) where {T <: RingElement}
-   check_parent(x, y)
+   b = check_parent(x, y, false)
+   !b && return false
    if length(x) != length(y)
       return false
    else
@@ -752,27 +754,27 @@ end
     ==(x::AbstractAlgebra.PolyElem{T}, y::T) where {T <: RingElem}
 > Return `true` if $x == y$.
 """
-==(x::AbstractAlgebra.PolyElem{T}, y::T) where T <: RingElem = ((length(x) == 0 && y == 0)
+ ==(x::AbstractAlgebra.PolyElem{T}, y::T) where T <: RingElem = ((length(x) == 0 && y == 0)
                         || (length(x) == 1 && coeff(x, 0) == y))
 
 @doc Markdown.doc"""
     ==(x::Generic.PolynomialElem, y::Union{Integer, Rational, AbstractFloat})
 > Return `true` if $x == y$ arithmetically, otherwise return `false`.
 """
-==(x::PolynomialElem, y::Union{Integer, Rational, AbstractFloat}) = ((length(x) == 0 && base_ring(x)(y) == 0)
+ ==(x::PolynomialElem, y::Union{Integer, Rational, AbstractFloat}) = ((length(x) == 0 && base_ring(x)(y) == 0)
                         || (length(x) == 1 && coeff(x, 0) == y))
 
 @doc Markdown.doc"""
     ==(x::T, y::AbstractAlgebra.PolyElem{T}) where T <: RingElem = y == x
 > Return `true` if $x = y$.
 """
-==(x::T, y::AbstractAlgebra.PolyElem{T}) where T <: RingElem = y == x
+ ==(x::T, y::AbstractAlgebra.PolyElem{T}) where T <: RingElem = y == x
 
 @doc Markdown.doc"""
     ==(x::Union{Integer, Rational, AbstractFloat}, y::AbstractAlgebra.PolyElem)
 > Return `true` if $x == y$ arithmetically, otherwise return `false`.
 """
-==(x::Union{Integer, Rational, AbstractFloat}, y::AbstractAlgebra.PolyElem) = y == x
+ ==(x::Union{Integer, Rational, AbstractFloat}, y::AbstractAlgebra.PolyElem) = y == x
 
 ###############################################################################
 #

--- a/src/generic/PuiseuxSeries.jl
+++ b/src/generic/PuiseuxSeries.jl
@@ -101,9 +101,10 @@ end
 
 isexact_type(a::Type{T}) where T <: PuiseuxSeriesElem = false
 
-function check_parent(a::PuiseuxSeriesElem, b::PuiseuxSeriesElem)
-   parent(a) != parent(b) &&
-             error("Incompatible Puiseux series rings in Puiseux series operation")
+function check_parent(a::PuiseuxSeriesElem, b::PuiseuxSeriesElem, throw::Bool = true)
+   fl = parent(a) != parent(b)
+   fl && throw && error("Incompatible Puiseux series rings in Puiseux series operation")
+   return !fl
 end
 
 ###############################################################################
@@ -523,11 +524,13 @@ end
 ###############################################################################
 
 function ==(a::PuiseuxSeriesElem{T}, b::PuiseuxSeriesElem{T}) where T <: RingElement
-    s = gcd(a.scale, b.scale)
-    zscale = div(a.scale*b.scale, s)
-    ainf = div(a.scale, s)
-    binf = div(b.scale, s)
-    return inflate(a.data, binf) == inflate(b.data, ainf)
+   fl = check_parent(a, b, false)
+   !fl && return false
+   s = gcd(a.scale, b.scale)
+   zscale = div(a.scale*b.scale, s)
+   ainf = div(a.scale, s)
+   binf = div(b.scale, s)
+   return inflate(a.data, binf) == inflate(b.data, ainf)
 end
 
 function isequal(a::PuiseuxSeriesElem{T}, b::PuiseuxSeriesElem{T}) where T <: RingElement

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -60,9 +60,10 @@ isexact_type(a::Type{T}) where T <: AbstractAlgebra.SeriesElem = false
 """
 var(a::SeriesRing) = a.S
 
-function check_parent(a::AbstractAlgebra.SeriesElem, b::AbstractAlgebra.SeriesElem)
-   parent(a) != parent(b) &&
-             error("Incompatible power series rings in power series operation")
+function check_parent(a::AbstractAlgebra.SeriesElem, b::AbstractAlgebra.SeriesElem, throw::Bool = true)
+   b = parent(a) != parent(b)
+   b && throw && error("Incompatible power series rings in power series operation")
+   return !b
 end
 
 ###############################################################################
@@ -71,7 +72,7 @@ end
 #
 ###############################################################################
 
-function Base.hash(a::AbstractAlgebra.SeriesElem, h::UInt)
+function Base.hash(a::AbstractAlgebra.RelSeriesElem, h::UInt)
    b = 0xb44d6896204881f3%UInt
    for i in 0:pol_length(a) - 1
       b = xor(b, hash(polcoeff(a, i), h), h)
@@ -732,7 +733,9 @@ end
 > equal to the minimum of the two precisions.
 """
 function ==(x::AbstractAlgebra.RelSeriesElem{T}, y::AbstractAlgebra.RelSeriesElem{T}) where {T <: RingElement}
-   check_parent(x, y)
+   b = check_parent(x, y, false)
+   !b && return false
+
    xval = valuation(x)
    xprec = precision(x)
    yval = valuation(y)

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -45,11 +45,15 @@ function check_parent_type(a::AbstractAlgebra.ResRing{T}, b::AbstractAlgebra.Res
    # exists only to check types of parents agree
 end
 
-function check_parent(a::AbstractAlgebra.ResElem, b::AbstractAlgebra.ResElem)
+function check_parent(a::AbstractAlgebra.ResElem, b::AbstractAlgebra.ResElem, throw::Bool = true)
    if parent(a) != parent(b)
       check_parent_type(parent(a), parent(b))
-      modulus(parent(a)) != modulus(parent(b)) && error("Incompatible moduli in residue operation") #CF: maybe extend to divisibility?
+      fl = modulus(parent(a)) != modulus(parent(b))
+      fl && throw && error("Incompatible moduli in residue operation")
+      return !fl
+      #CF: maybe extend to divisibility?
    end
+   return true
 end
 
 ###############################################################################
@@ -320,7 +324,8 @@ end
 > equal to the minimum of the two precisions.
 """
 function ==(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
-   check_parent(a, b)
+   fl = check_parent(a, b, false)
+   !fl && return false
    return data(a) == data(b)
 end
 
@@ -332,7 +337,8 @@ end
 > they declared equal by this function.
 """
 function isequal(a::AbstractAlgebra.ResElem{T}, b::AbstractAlgebra.ResElem{T}) where {T <: RingElement}
-   check_parent(a, b)
+   fl = check_parent(a, b, false)
+   !fl && return false
    return isequal(data(a), data(b))
 end
 

--- a/src/generic/ResidueField.jl
+++ b/src/generic/ResidueField.jl
@@ -45,11 +45,14 @@ function check_parent_type(a::AbstractAlgebra.ResField{T}, b::AbstractAlgebra.Re
    # exists only to check types of parents agree
 end
 
-function check_parent(a::AbstractAlgebra.ResFieldElem, b::AbstractAlgebra.ResFieldElem)
+function check_parent(a::AbstractAlgebra.ResFieldElem, b::AbstractAlgebra.ResFieldElem, throw::Bool = true)
    if parent(a) != parent(b)
       check_parent_type(parent(a), parent(b))
-      modulus(parent(a)) != modulus(parent(b)) && error("Incompatible moduli in residue operation") #CF: maybe extend to divisibility?
+      fl = modulus(parent(a)) != modulus(parent(b))
+      fl && throw && error("Incompatible moduli in residue operation") #CF: maybe extend to divisibility?
+      return !fl
    end
+   return true
 end
 
 ###############################################################################
@@ -332,7 +335,8 @@ end
 > equal to the minimum of the two precisions.
 """
 function ==(a::AbstractAlgebra.ResFieldElem{T}, b::AbstractAlgebra.ResFieldElem{T}) where {T <: RingElement}
-   check_parent(a, b)
+   fl = check_parent(a, b, false)
+   !fl && return false
    return data(a) == data(b)
 end
 

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -74,6 +74,13 @@ function test_abs_series_constructors()
 
    @test isa(l, Generic.AbsSeries)
 
+   @test x in [x, y]
+   @test x in [y, x]
+   @test !(x in [y])
+
+   @test x in keys(Dict(x => 1))
+   @test !(y in keys(Dict(x => 1)))
+
    println("PASS")
 end
 

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -40,6 +40,16 @@ function test_gen_frac_constructors()
 
    @test isa(T(x + 2, x + 1)//T(x, x + 2), Generic.Frac)
 
+   TT = FractionField(PolynomialRing(QQ, "x")[1])
+   a = TT(1)
+   b = T(2)
+
+   @test a in [a, b]
+   @test a in [b, a]
+   @test !(a in [b])
+   @test a in keys(Dict(a => 1))
+   @test !(b in keys(Dict(a => 1)))
+
    println("PASS")
 end
 

--- a/test/generic/LaurentSeries-test.jl
+++ b/test/generic/LaurentSeries-test.jl
@@ -93,6 +93,13 @@ function test_laurent_series_constructors()
 
    @test isa(l, Generic.LaurentSeriesElem)
 
+   @test x in [x, y]
+   @test x in [y, x]
+   @test !(x in [y])
+
+   @test x in keys(Dict(x => 1))
+   @test !(y in keys(Dict(x => 1)))
+
    println("PASS")
 end
 

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -65,6 +65,14 @@ function test_gen_mpoly_constructors()
       f3 = finish(C)
 
       @test f1 == f3
+
+      _, varlist = PolynomialRing(QQ, var_names)
+      y = varlist[1]
+      @test x in [x, y]
+      @test x in [y, x]
+      @test !(x in [y])
+      @test x in keys(Dict(x => 1))
+      @test !(y in keys(Dict(x => 1)))
    end
 
    println("PASS")

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -155,6 +155,16 @@ function test_gen_mat_constructors()
    @test isa(M4, Generic.Mat{elem_type(R)})
    @test M4.base_ring == R
 
+   x = zero_matrix(R, 2, 2)
+   y = zero_matrix(ZZ, 2, 3)
+
+   @test x in [x, y]
+   @test x in [y, x]
+   @test !(x in [y])
+
+   @test x in keys(Dict(x => 1))
+   @test !(y in keys(Dict(x => 1)))
+
    println("PASS")
 end
 

--- a/test/generic/MatrixAlgebra-test.jl
+++ b/test/generic/MatrixAlgebra-test.jl
@@ -117,6 +117,16 @@ function test_gen_matalg_constructors()
    @test_throws ErrorConstrDimMismatch S([t, t^2])
    @test_throws ErrorConstrDimMismatch S([t, t^2, t^3, t^4, t^5, t^6, t^7, t^8, t^9, t^10])
 
+   x = zero_matrix(R, 2, 2)
+   y = zero_matrix(ZZ, 2, 3)
+
+   @test x in [x, y]
+   @test x in [y, x]
+   @test !(x in [y])
+
+   @test x in keys(Dict(x => 1))
+   @test !(y in keys(Dict(x => 1)))
+
    println("PASS")
 end
 

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -76,6 +76,13 @@ function test_gen_poly_constructors()
 
    @test isa(n, PolyElem)
 
+   @test x in [x, y]
+   @test x in [y, x]
+   @test !(x in [y])
+
+   @test x in keys(Dict(x => 1))
+   @test !(y in keys(Dict(x => 1)))
+
    println("PASS")
 end
 

--- a/test/generic/PuiseuxSeries-test.jl
+++ b/test/generic/PuiseuxSeries-test.jl
@@ -85,6 +85,13 @@ function test_puiseux_series_constructors()
 
    @test isa(l, Generic.PuiseuxSeriesElem)
 
+   @test x in [x, y]
+   @test x in [y, x]
+   @test !(x in [y])
+
+   @test x in keys(Dict(x => 1))
+   @test !(y in keys(Dict(x => 1)))
+
    println("PASS")
 end
 

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -74,6 +74,13 @@ function test_rel_series_constructors()
 
    @test isa(l, Generic.RelSeries)
 
+   @test x in [x, y]
+   @test x in [y, x]
+   @test !(x in [y])
+
+   @test x in keys(Dict(x => 1))
+   @test !(y in keys(Dict(x => 1)))
+
    println("PASS")
 end
 

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -40,6 +40,16 @@ function test_gen_res_constructors()
 
    @test isa(g, Generic.Res)
 
+   S = Generic.ResidueRing(B, 164538890)
+   x = R(1)
+   y = S(1)
+   @test x in [x, y]
+   @test x in [y, x]
+   @test !(x in [y])
+
+   @test x in keys(Dict(x => 1))
+   @test !(y in keys(Dict(x => 1)))
+
    println("PASS")
 end
 

--- a/test/generic/ResidueField-test.jl
+++ b/test/generic/ResidueField-test.jl
@@ -40,6 +40,17 @@ function test_gen_res_field_constructors()
 
    @test isa(g, Generic.ResF)
 
+   S = Generic.ResidueRing(B, 2)
+   x = R(1)
+   y = S(1)
+   @test x in [x, y]
+   @test x in [y, x]
+   @test !(x in [y])
+
+   @test x in keys(Dict(x => 1))
+   @test !(y in keys(Dict(x => 1)))
+
+
    println("PASS")
 end
 


### PR DESCRIPTION
This fixes the following bug:
```julia
julia> a = zero_matrix(ZZ, 2, 3)
[0 0 0]
[0 0 0]

julia> b = zero_matrix(ZZ, 3, 3)
[0 0 0]
[0 0 0]
[0 0 0]

julia> a in [b, a]
ERROR: Incompatible matrix spaces in matrix operation
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] check_parent at /home/thofmann/.julia/dev/AbstractAlgebra/src/generic/Matrix.jl:108 [inlined]
 [3] ==(::AbstractAlgebra.Generic.Mat{BigInt}, ::AbstractAlgebra.Generic.Mat{BigInt}) at /home/thofmann/.julia/dev/AbstractAlgebra/src/generic/Matrix.jl:680
 [4] in(::AbstractAlgebra.Generic.Mat{BigInt}, ::Array{AbstractAlgebra.Generic.Mat{BigInt},1}) at ./operators.jl:950
 [5] top-level scope at none:0

julia> a in [a, b]
true
```