### PR TITLE
fix change_base_ring and map_entries for custom matrices

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -307,7 +307,7 @@ end
 ################################################################################
 
 function copy(d::MatSpaceElem{T}) where T <: RingElement
-   z = _similar(d, base_ring(d), nrows(d), ncols(d))
+   z = similar(d)
    for i = 1:nrows(d)
       for j = 1:ncols(d)
          z[i, j] = d[i, j]
@@ -317,7 +317,7 @@ function copy(d::MatSpaceElem{T}) where T <: RingElement
 end
 
 function deepcopy_internal(d::MatSpaceElem{T}, dict::IdDict) where T <: RingElement
-   z = _similar(d, base_ring(d), nrows(d), ncols(d))
+   z = similar(d)
    for i = 1:nrows(d)
       for j = 1:ncols(d)
          z[i, j] = deepcopy(d[i, j])
@@ -4920,13 +4920,18 @@ end
 #
 ###############################################################################
 
+# like change_base_ring, but without initializing the entries
+# this function exists until a better API is implemented
+_change_base_ring(R::Ring, a::MatElem) = zero_matrix(R, nrows(a), ncols(a))
+_change_base_ring(R::Ring, a::MatAlgElem) = MatrixAlgebra(R, nrows(a))()
+
 @doc Markdown.doc"""
     change_base_ring(R::Ring, M::MatrixElem)
 
 > Return the matrix obtained by coercing each entry into `R`.
 """
 function change_base_ring(R::Ring, M::MatrixElem)
-   N = similar(M, R)
+   N = _change_base_ring(R, M)
    for i=1:nrows(M), j=1:ncols(M)
       N[i,j] = R(M[i,j])
    end
@@ -4965,9 +4970,9 @@ Base.map!(f, dst::MatrixElem, src::MatrixElem) = map_entries!(f, dst, src)
 > Transform matrix `a` by applying `f` on each element.
 """
 function map_entries(f, a::MatrixElem)
-   isempty(a) && return similar(a, parent(f(zero(base_ring(a)))))
+   isempty(a) && return _change_base_ring(parent(f(zero(base_ring(a)))), a)
    b11 = f(a[1, 1])
-   b = similar(a, parent(b11))
+   b = _change_base_ring(parent(b11), a)
    b[1, 1] = b11
    for i = 1:nrows(a), j = 1:ncols(a)
       i == j == 1 && continue

--- a/src/generic/MatrixAlgebra.jl
+++ b/src/generic/MatrixAlgebra.jl
@@ -138,7 +138,7 @@ zero(x::AbstractAlgebra.MatAlgElem, n::Int) = zero!(similar(x, n))
 ################################################################################
 
 function copy(d::MatAlgElem{T}) where T <: RingElement
-   z = _similar(d, base_ring(d), nrows(d), ncols(d))
+   z = similar(d)
    for i = 1:nrows(d)
       for j = 1:ncols(d)
          z[i, j] = d[i, j]
@@ -148,7 +148,7 @@ function copy(d::MatAlgElem{T}) where T <: RingElement
 end
 
 function deepcopy_internal(d::MatAlgElem{T}, dict::IdDict) where T <: RingElement
-   z = _similar(d, base_ring(d), nrows(d), ncols(d))
+   z = similar(d)
    for i = 1:nrows(d)
       for j = 1:ncols(d)
          z[i, j] = deepcopy(d[i, j])

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -87,6 +87,45 @@ Base.getindex(a::MyTestMatrix{T}, r::Int, c::Int) where T = a.d
 
 Base.size(a::MyTestMatrix{T}) where T = a.dim, a.dim
 
+# Simulate user Field, together with a specialized matrix type
+# (like fmpz / fmpz_mat)
+struct F2 <: AbstractAlgebra.Field end
+
+Base.zero(::F2) = F2Elem(false)
+
+struct F2Elem <: AbstractAlgebra.FieldElem
+   x::Bool
+end
+
+Base.:-(x::F2Elem) = x
+(f2::F2)(x::F2Elem) = x
+AbstractAlgebra.parent(x::F2Elem) = F2()
+
+struct F2Matrix <: AbstractAlgebra.MatElem{F2Elem}
+   m::Generic.MatSpaceElem{F2Elem}
+end
+
+AbstractAlgebra.nrows(a::F2Matrix) = nrows(a.m)
+AbstractAlgebra.ncols(a::F2Matrix) = ncols(a.m)
+AbstractAlgebra.parent_type(::Type{F2Elem}) = F2
+AbstractAlgebra.elem_type(::Type{F2}) = F2Elem
+AbstractAlgebra.base_ring(::F2Matrix) = F2()
+
+Base.getindex(a::F2Matrix, r::Int64, c::Int64) = a.m[r, c]
+Base.setindex!(a::F2Matrix, x::F2Elem, r::Int64, c::Int64) = a.m[r, c] = x
+Base.similar(x::F2Matrix, R::F2, r::Int, c::Int) = F2Matrix(similar(x.m, r, c))
+
+function AbstractAlgebra.zero_matrix(R::F2, r::Int, c::Int)
+   mat = Array{F2Elem}(undef, r, c)
+   for i=1:r, j=1:c
+      mat[i, j] = zero(R)
+   end
+   z = Generic.MatSpaceElem{F2Elem}(mat)
+   z.base_ring = R
+   return F2Matrix(z)
+end
+
+
 @testset "Generic.Mat.constructors..." begin
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
@@ -440,6 +479,10 @@ end
    @test iszero(A + (-A))
    @test A == -(-A)
    @test -A == S(-A.entries)
+
+   z = zero_matrix(F2(), 2, 3)
+   @test -z   isa F2Matrix
+   @test -z.m isa Generic.MatSpaceElem{F2Elem}
 end
 
 @testset "Generic.Mat.sub..." begin
@@ -2406,6 +2449,10 @@ end
          @test MQ * NQ == MNQ
       end
    end
+
+   z = zero_matrix(F2(), 2, 3)
+   @test change_base_ring(F2(), z)   isa F2Matrix
+   @test change_base_ring(F2(), z.m) isa F2Matrix
 end
 
 @testset "Generic.Mat.map..." begin
@@ -2446,6 +2493,10 @@ end
          end
       end
    end
+
+   z = zero_matrix(F2(), 2, 3)
+   @test map(identity, z)   isa F2Matrix
+   @test map(identity, z.m) isa F2Matrix
 end
 
 @testset "Generic.Mat.similar/zero..." begin
@@ -2476,6 +2527,20 @@ end
          end
       end
    end
+
+   z = zero_matrix(F2(), 2, 3)
+   @test z isa F2Matrix
+   @test similar(z)       isa F2Matrix
+   @test similar(z, 2, 3) isa F2Matrix
+   @test zero(z)          isa F2Matrix
+   @test zero(z, 2, 3)    isa F2Matrix
+
+   m = z.m
+   @test m                isa Generic.MatSpaceElem{F2Elem}
+   @test similar(m)       isa Generic.MatSpaceElem{F2Elem}
+   @test similar(m, 2, 3) isa Generic.MatSpaceElem{F2Elem}
+   @test zero(m)          isa Generic.MatSpaceElem{F2Elem}
+   @test zero(m, 2, 3)    isa Generic.MatSpaceElem{F2Elem}
 end
 
 @testset "Generic.Mat.printing..." begin


### PR DESCRIPTION
These functions should select the best dense matrix type
for the given destination ring.

Fixes part of https://github.com/Nemocas/Nemo.jl/issues/651#issuecomment-540493003.